### PR TITLE
Fix incorrect syntax highlighting on lean4-debugging keyword

### DIFF
--- a/lean4-syntax.el
+++ b/lean4-syntax.el
@@ -65,9 +65,9 @@
 (defconst lean4-warnings '("sorry") "Lean warnings.")
 (defconst lean4-warnings-regexp
   (eval `(rx word-start (or ,@lean4-warnings) word-end)))
-(defconst lean4-debugging '("unreachable" "panic" "assert" "dbgTrace") "Lean debugging.")
+(defconst lean4-debugging '("unreachable!" "panic!" "assert!" "dbg_trace") "Lean debugging.")
 (defconst lean4-debugging-regexp
-  (eval `(rx word-start (or ,@lean4-debugging))))
+  (eval `(rx word-start (or ,@lean4-debugging) word-end)))
 
 
 (defconst lean4-syntax-table
@@ -187,6 +187,8 @@
      (,(rx word-start (group (or "Prop" "Type" "Sort")) ".") (1 'font-lock-type-face))
      ;; String
      ("\"[^\"]*\"" . 'font-lock-string-face)
+     ;; Debugging builtins
+     (,lean4-debugging-regexp . 'font-lock-warning-face)
      ;; ;; Constants
      (,lean4-constants-regexp . 'font-lock-constant-face)
      (,lean4-numerals-regexp . 'font-lock-constant-face)
@@ -194,7 +196,6 @@
      (,(rx symbol-start "_" symbol-end) . 'font-lock-preprocessor-face)
      ;; warnings
      (,lean4-warnings-regexp . 'font-lock-warning-face)
-     (,lean4-debugging-regexp . 'font-lock-warning-face)
      ;; escaped identifiers
      (,(rx (and (group "«") (group (one-or-more (not (any "»")))) (group "»")))
       (1 font-lock-comment-face t)


### PR DESCRIPTION
I also encountered #36 and decided to give it a try.

### How the bug was introduced

The original code was added in https://github.com/leanprover/lean4/commit/ba4fdce508351bb222e58769fa1ce19a938a1f96 , where you can see `(defconst lean4-debugging '("unreachable" "panic" "assert" "dbgTrace") "lean debugging")` corresponds to 
```lean
@[builtinTermParser] def panic       := parser!:leadPrec "panic! " >> termParser
@[builtinTermParser] def unreachable := parser!:leadPrec "unreachable!"
@[builtinTermParser] def dbgTrace    := parser!:leadPrec "dbgTrace! " >> termParser >> "; " >> termParser
@[builtinTermParser] def assert      := parser!:leadPrec "assert! " >> termParser >> "; " >> termParser
```

This is where the we should improve into
```diff
-(defconst lean4-debugging '("unreachable" "panic" "assert" "dbgTrace") "lean debugging")
-(defconst lean4-debugging-regexp
-  (eval `(rx word-start (or ,@lean4-debugging))))
+(defconst lean4-debugging '("unreachable!" "panic!" "assert!" "dbgTrace!") "lean debugging")
+(defconst lean4-debugging-regexp
+  (eval `(rx word-start (or ,@lean4-debugging) word-end)))
```

### How to fix it

Now, the other 3 builtin terms didn't change, but `dbgTrace!` was renamed to `dbg_trace` (https://github.com/leanprover/lean4/blob/6fce8f7d5cd18a4419bca7fd51780c71c9b1cc5a/src/Lean/Parser/Term.lean#L781)

That explains line 68-70. But there are 2 more things to explain.

1. Why switch the order?
    This is because `lean4-constants-regexp` would already fontify `!`, so that later lean4-debugging won't fontify those with an `!` again.
2. Why after the fix, you won't actually see font-lock-warning-face as if it is not working?
    The code is actually working, but overwritten by lsp server. In da21b1037, we enabled `lsp-semantic-tokens-enable`, which is an alias of `lsp-enable-semantic-highlighting`. It should work correctly when lsp server is not present. (I tested using https://github.com/Lindydancer/font-lock-studio)

### look and feel:

before the fix:
![Screenshot_20240312_222119](https://github.com/leanprover-community/lean4-mode/assets/96765450/70a0584d-c8f3-402d-b802-3b555de77343)

after the fix:
![Screenshot_20240312_231512](https://github.com/leanprover-community/lean4-mode/assets/96765450/41c69743-d4ac-4c30-9e38-4deb779e2b75)
